### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 language: php
 
 php:
-  # The adhocore/cron-expr should run fine with php 5.4+, but phpunit 5.7 requires php 5.6+
-  # - 5.4
-  # - 5.5
+  - 5.4
+  - 5.5
   - 5.6
   - 7.0
   - 7.1
   - 7.2
+  - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
 
 install:
   - composer install --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,9 @@
         }
     },
     "require": {
+        "php": ">=5.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.0"
+        "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5"
     }
 }


### PR DESCRIPTION
# Changed log
- Using the class-based PHPUnit namespace to be compatible with the stable PHPUnit versions.
- Add the `php-nightly` test in Travis CI build and it allows that can allow failure.
- Set the different PHPUnit version to support the multiple PHP versions.
- Using the annotation `expectedException` to be compatible with the different PHPUnit versions.
- Separate the `scheduleProvider` and add the new test is for `invalidScheduleProvider`.
- Using the `assertInternalType` to assert the result type.