### PR TITLE
Remove back-slash before native functions

### DIFF
--- a/src/Expression.php
+++ b/src/Expression.php
@@ -109,10 +109,10 @@ class Expression
             $expr = static::$expressions[$expr];
         }
 
-        $expr = \str_ireplace(\array_keys(static::$literals), \array_values(static::$literals), $expr);
-        $expr = \explode(' ', $expr);
+        $expr = str_ireplace(array_keys(static::$literals), array_values(static::$literals), $expr);
+        $expr = explode(' ', $expr);
 
-        if (\count($expr) < 5 || \count($expr) > 6) {
+        if (count($expr) < 5 || count($expr) > 6) {
             throw new \UnexpectedValueException(
                 'Cron $expr should have 5 or 6 segments delimited by space'
             );
@@ -120,7 +120,7 @@ class Expression
 
         $time = static::normalizeTime($time);
 
-        $time = \array_map('intval', \explode(' ', \date('i G j n w Y t d m N', $time)));
+        $time = array_map('intval', explode(' ', date('i G j n w Y t d m N', $time)));
 
         return [$expr, $time];
     }
@@ -128,9 +128,9 @@ class Expression
     protected function normalizeTime($time)
     {
         if (empty($time)) {
-            $time = \time();
-        } elseif (\is_string($time)) {
-            $time = \strtotime($time);
+            $time = time();
+        } elseif (is_string($time)) {
+            $time = strtotime($time);
         } elseif ($time instanceof \DateTime) {
             $time = $time->getTimestamp();
         }

--- a/src/SegmentChecker.php
+++ b/src/SegmentChecker.php
@@ -31,7 +31,7 @@ class SegmentChecker
     public function checkDue($segment, $pos, $time)
     {
         $isDue   = true;
-        $offsets = \explode(',', \trim($segment));
+        $offsets = explode(',', trim($segment));
 
         foreach ($offsets as $offset) {
             if (null === $isDue = $this->isOffsetDue($offset, $pos, $time)) {
@@ -59,15 +59,15 @@ class SegmentChecker
      */
     protected function isOffsetDue($offset, $pos, $time)
     {
-        if (\strpos($offset, '/') !== false) {
+        if (strpos($offset, '/') !== false) {
             return $this->validator->inStep($time[$pos], $offset);
         }
 
-        if (\strpos($offset, '-') !== false) {
+        if (strpos($offset, '-') !== false) {
             return $this->validator->inRange($time[$pos], $offset);
         }
 
-        if (\is_numeric($offset)) {
+        if (is_numeric($offset)) {
             return $time[$pos] == $offset;
         }
 
@@ -76,7 +76,7 @@ class SegmentChecker
 
     protected function checkModifier($offset, $pos, $time)
     {
-        $isModifier = \strpbrk($offset, 'LCW#');
+        $isModifier = strpbrk($offset, 'LCW#');
 
         if ($pos === 2 && $isModifier) {
             return $this->validator->isValidMonthDay($offset, $time);

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -13,24 +13,24 @@ class Validator
 {
     public function inRange($value, $offset)
     {
-        $parts = \explode('-', $offset);
+        $parts = explode('-', $offset);
 
         return $parts[0] <= $value && $value <= $parts[1];
     }
 
     public function inStep($value, $offset)
     {
-        if (\strpos($offset, '*/') !== false || \strpos($offset, '0/') !== false) {
-            $parts = \explode('/', $offset, 2);
+        if (strpos($offset, '*/') !== false || strpos($offset, '0/') !== false) {
+            $parts = explode('/', $offset, 2);
 
             return $value % $parts[1] === 0;
         }
 
-        $parts    = \explode('/', $offset, 2);
-        $subparts = \explode('-', $parts[0], 2) + [1 => $value];
+        $parts    = explode('/', $offset, 2);
+        $subparts = explode('-', $parts[0], 2) + [1 => $value];
 
         return ($subparts[0] <= $value && $value <= $subparts[1] && $parts[1])
-            ? \in_array($value, \range($subparts[0], $subparts[1], $parts[1]))
+            ? in_array($value, range($subparts[0], $subparts[1], $parts[1]))
             : false;
     }
 
@@ -50,9 +50,9 @@ class Validator
             return $time[2] == $time[6];
         }
 
-        if ($pos = \strpos($value, 'W')) {
-            $value = \substr($value, 0, $pos);
-            $month = \str_pad($time[8], 2, '0', \STR_PAD_LEFT);
+        if ($pos = strpos($value, 'W')) {
+            $value = substr($value, 0, $pos);
+            $month = str_pad($time[8], 2, '0', STR_PAD_LEFT);
 
             return $this->isClosestWeekDay($value, $month, $time);
         }
@@ -66,8 +66,8 @@ class Validator
                 continue;
             }
 
-            $incr  = \str_pad($incr, 2, '0', \STR_PAD_LEFT);
-            $parts = \explode(' ', \date('N m j', \strtotime("{$time[5]}-$month-$incr")));
+            $incr  = str_pad($incr, 2, '0', STR_PAD_LEFT);
+            $parts = explode(' ', date('N m j', strtotime("{$time[5]}-$month-$incr")));
             if ($parts[0] < 6 && $parts[1] == $month) {
                 return $time[2] == $parts[2];
             }
@@ -90,33 +90,33 @@ class Validator
      */
     public function isValidWeekDay($value, $time)
     {
-        $month = \str_pad($time[8], 2, '0', \STR_PAD_LEFT);
+        $month = str_pad($time[8], 2, '0', STR_PAD_LEFT);
 
-        if (\strpos($value, 'L')) {
+        if (strpos($value, 'L')) {
             return $this->isLastWeekDay($value, $month, $time);
         }
 
-        if (!\strpos($value, '#')) {
+        if (!strpos($value, '#')) {
             return null;
         }
 
-        list($day, $nth) = \explode('#', \str_replace('0#', '7#', $value));
+        list($day, $nth) = explode('#', str_replace('0#', '7#', $value));
 
         if (!$this->isNthWeekDay($day, $nth) || $time[9] != $day) {
             return false;
         }
 
-        return \intval($time[7] / 7) == $nth - 1;
+        return intval($time[7] / 7) == $nth - 1;
     }
 
     protected function isLastWeekDay($value, $month, $time)
     {
-        $value = \explode('L', \str_replace('7L', '0L', $value));
+        $value = explode('L', str_replace('7L', '0L', $value));
         $decr  = $time[6];
 
         for ($i = 0; $i < 7; $i++) {
             $decr -= $i;
-            if (\date('w', \strtotime("{$time[5]}-$month-$decr")) == $value[0]) {
+            if (date('w', strtotime("{$time[5]}-$month-$decr")) == $value[0]) {
                 return $time[2] == $decr;
             }
         }


### PR DESCRIPTION
# Changed log
- Remove the back-slash before the native PHP functions because the native PHP functions have already been loaded before loading the class with specific namespace in PHP run time.
And the native PHP functions will not effect the namespace. The more details are available [here](http://php.net/manual/en/language.namespaces.fallback.php).
- The Travis CI build is broken in this PR, but it's [passed](https://travis-ci.org/peter279k/cron-expr/builds/403963125) in my branch of forked repository.